### PR TITLE
Use Generic parameter in Array extension

### DIFF
--- a/Sources/SwiftRichString/Extensions.swift
+++ b/Sources/SwiftRichString/Extensions.swift
@@ -75,7 +75,7 @@ public extension Array where Element: Style {
 	/// Return the index and the instance of the first default Style defined in an array of Style
 	///
 	/// - Returns: tuple of index+instance or nil if not present
-	internal func defaultStyle() -> (index: Int?, item: Style?) {
+	internal func defaultStyle() -> (index: Int?, item: Element?) {
 		let defaultIndex = self.index(where: {
 			if case .default = $0.name { return true }
 			return false


### PR DESCRIPTION
This update will allow to use this library in Xcode 9 (with Swift 3.2)