### PR TITLE
Update 'characters' is deprecated warning

### DIFF
--- a/Sources/SwiftRichString/AttributedString+Extension.swift
+++ b/Sources/SwiftRichString/AttributedString+Extension.swift
@@ -110,7 +110,7 @@ public extension NSMutableAttributedString {
 	/// - Parameter styles: styles to apply
 	/// - Returns: self to allow any chain
 	public func add(styles: Style...) -> NSMutableAttributedString {
-		self.addAttributes(styles.attributesDictionary, range: NSMakeRange(0, self.string.characters.count))
+		self.addAttributes(styles.attributesDictionary, range: NSMakeRange(0, self.string.count))
 		return self
 	}
 	
@@ -133,7 +133,7 @@ public extension NSMutableAttributedString {
 	/// - Parameter styles: styles to apply
 	/// - Returns: self to allow any chain
 	public func set(styles: Style...) -> NSMutableAttributedString {
-		self.setAttributes(styles.attributesDictionary, range: NSMakeRange(0, self.string.characters.count))
+		self.setAttributes(styles.attributesDictionary, range: NSMakeRange(0, self.string.count))
 		return self
 	}
 	

--- a/Sources/SwiftRichString/Colors.swift
+++ b/Sources/SwiftRichString/Colors.swift
@@ -61,7 +61,7 @@ public extension SRColor {
 			return
 		}
 		
-		switch (hexString.characters.count) {
+		switch (hexString.count) {
 		case 3:
 			let hex3 = UInt16(hexValue)
 			let divisor = CGFloat(15)

--- a/Sources/SwiftRichString/MarkupString.swift
+++ b/Sources/SwiftRichString/MarkupString.swift
@@ -135,7 +135,7 @@ public class MarkupString {
 							plainText += "\n"
 							continue
 						}
-						let endIndex = plainText.characters.count
+						let endIndex = plainText.count
 						if tag.isOpenTag == true {
 							// it's an open tag, store the start index
 							// (the upperbund is temporary the same of the lower bound, we will update it


### PR DESCRIPTION
This update addresses the 'characters' is deprecated: Please use String or Substring directly is deprecated warning in Xcode 9.1

