### PR TITLE
Added support for Dynamic Text

### DIFF
--- a/ExampleiOS/ViewController.swift
+++ b/ExampleiOS/ViewController.swift
@@ -26,10 +26,12 @@ class ViewController: UIViewController {
 		}
 		let boldStyle = Style {
 			$0.font = UIFont.boldSystemFont(ofSize: self.baseFontSize)
-            $0.dynamicText = DynamicText {
-                $0.style = .body
-                $0.maximumSize = 35.0
-                $0.traitCollection = UITraitCollection(userInterfaceIdiom: .phone)
+            if #available(iOS 11.0, *) {
+                $0.dynamicText = DynamicText {
+                    $0.style = .body
+                    $0.maximumSize = 35.0
+                    $0.traitCollection = UITraitCollection(userInterfaceIdiom: .phone)
+                }
             }
 		}
 		let italicStyle = Style {

--- a/ExampleiOS/ViewController.swift
+++ b/ExampleiOS/ViewController.swift
@@ -21,22 +21,23 @@ class ViewController: UIViewController {
 		
 		let headerStyle = Style {
 			$0.font = UIFont.boldSystemFont(ofSize: self.baseFontSize * 1.15)
-            $0.adjustsToDynamicSize = true
+            $0.adjustsToDynamicSize = false
 			$0.lineSpacing = 1
 			$0.kerning = Kerning.adobe(-20)
 		}
 		let boldStyle = Style {
 			$0.font = UIFont.boldSystemFont(ofSize: self.baseFontSize)
             $0.adjustsToDynamicSize = true
+            $0.textStyle = UIFont.TextStyle.callout
 		}
 		let italicStyle = Style {
 			$0.font = UIFont.italicSystemFont(ofSize: self.baseFontSize)
-            $0.adjustsToDynamicSize = true
+            $0.adjustsToDynamicSize = false
 		}
 		
 		let style = StyleGroup(base: Style {
 			$0.font = UIFont.systemFont(ofSize: self.baseFontSize)
-            $0.adjustsToDynamicSize = true
+            $0.adjustsToDynamicSize = false
 			$0.lineSpacing = 2
 			$0.kerning = Kerning.adobe(-15)
 			}, [

--- a/ExampleiOS/ViewController.swift
+++ b/ExampleiOS/ViewController.swift
@@ -21,18 +21,22 @@ class ViewController: UIViewController {
 		
 		let headerStyle = Style {
 			$0.font = UIFont.boldSystemFont(ofSize: self.baseFontSize * 1.15)
+            $0.adjustsToDynamicSize = true
 			$0.lineSpacing = 1
 			$0.kerning = Kerning.adobe(-20)
 		}
 		let boldStyle = Style {
 			$0.font = UIFont.boldSystemFont(ofSize: self.baseFontSize)
+            $0.adjustsToDynamicSize = true
 		}
 		let italicStyle = Style {
 			$0.font = UIFont.italicSystemFont(ofSize: self.baseFontSize)
+            $0.adjustsToDynamicSize = true
 		}
 		
 		let style = StyleGroup(base: Style {
 			$0.font = UIFont.systemFont(ofSize: self.baseFontSize)
+            $0.adjustsToDynamicSize = true
 			$0.lineSpacing = 2
 			$0.kerning = Kerning.adobe(-15)
 			}, [
@@ -50,17 +54,13 @@ class ViewController: UIViewController {
 				},
 				"sup": Style {
 					$0.font = UIFont.systemFont(ofSize: self.baseFontSize / 1.2)
+                    $0.adjustsToDynamicSize = true
 					$0.baselineOffset = Float(self.baseFontSize) / 3.5
 				}])
 		
 		self.textView?.attributedText = bodyHTML.set(style: style)
+        if #available(iOS 10.0, *) {
+            self.textView?.adjustsFontForContentSizeCategory = true
+        }
 	}
-
-	override func didReceiveMemoryWarning() {
-		super.didReceiveMemoryWarning()
-		// Dispose of any resources that can be recreated.
-	}
-
-
 }
-

--- a/ExampleiOS/ViewController.swift
+++ b/ExampleiOS/ViewController.swift
@@ -21,23 +21,22 @@ class ViewController: UIViewController {
 		
 		let headerStyle = Style {
 			$0.font = UIFont.boldSystemFont(ofSize: self.baseFontSize * 1.15)
-            $0.adjustsToDynamicSize = false
 			$0.lineSpacing = 1
 			$0.kerning = Kerning.adobe(-20)
 		}
 		let boldStyle = Style {
 			$0.font = UIFont.boldSystemFont(ofSize: self.baseFontSize)
-            $0.adjustsToDynamicSize = true
-            $0.textStyle = UIFont.TextStyle.callout
+            $0.dynamicTextSize = DynamicTextSize {
+                $0.textStyle = .body
+                $0.maximumSize = 35.0
+            }
 		}
 		let italicStyle = Style {
 			$0.font = UIFont.italicSystemFont(ofSize: self.baseFontSize)
-            $0.adjustsToDynamicSize = false
 		}
 		
 		let style = StyleGroup(base: Style {
 			$0.font = UIFont.systemFont(ofSize: self.baseFontSize)
-            $0.adjustsToDynamicSize = false
 			$0.lineSpacing = 2
 			$0.kerning = Kerning.adobe(-15)
 			}, [
@@ -55,7 +54,6 @@ class ViewController: UIViewController {
 				},
 				"sup": Style {
 					$0.font = UIFont.systemFont(ofSize: self.baseFontSize / 1.2)
-                    $0.adjustsToDynamicSize = true
 					$0.baselineOffset = Float(self.baseFontSize) / 3.5
 				}])
 		

--- a/ExampleiOS/ViewController.swift
+++ b/ExampleiOS/ViewController.swift
@@ -26,9 +26,10 @@ class ViewController: UIViewController {
 		}
 		let boldStyle = Style {
 			$0.font = UIFont.boldSystemFont(ofSize: self.baseFontSize)
-            $0.dynamicTextSize = DynamicTextSize {
-                $0.textStyle = .body
+            $0.dynamicText = DynamicText {
+                $0.style = .body
                 $0.maximumSize = 35.0
+                $0.traitCollection = UITraitCollection(userInterfaceIdiom: .phone)
             }
 		}
 		let italicStyle = Style {

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Full changelog is available in [CHANGELOG.md](CHANGELOG.md) file.
 	- [Apply styles to `String` & `Attributed String`](#manualstyling)
 	- [Fonts & Colors in `Style`](#fontscolors)
 	- [Derivating a `Style`](#derivatingstyle)
+	- [Conforming to `Dynamic Type`](#dynamictype)
 - [The `StyleManager`](#stylemanager)
 	- [Register globally available styles](#globalregister)
 	- [Defer style creation on demand](#defer)
@@ -359,7 +360,26 @@ let subStyle = bold.byAdding {
 	$0.alignment = center
 	$0.color = UIColor.red
 }
+```
+
+<a name="dynamictype"/>
+
+### Conforming to `Dynamic Type`
+
+To support your fonts/text to dynammically scale based on the users preffered content size, you can implement style's `dynamicText` property. UIFontMetrics properties are wrapped inside `DynamicText` class.
+
+
+```swift
+let style = Style {
+	$0.font = UIFont.boldSystemFont(ofSize: 16.0)
+	$0.dynamicText = DynamicText {
+		$0.style = .body
+		$0.maximumSize = 35.0
+		$0.traitCollection = UITraitCollection(userInterfaceIdiom: .phone)
+    }
+}
 ``` 
+
 <a name="stylemanager"/>
 
 ## The `StyleManager`

--- a/Sources/SwiftRichString/Attributes/DynamicText.swift
+++ b/Sources/SwiftRichString/Attributes/DynamicText.swift
@@ -1,5 +1,5 @@
 //
-//  DynamicTextSize.swift
+//  DynamicText.swift
 //  SwiftRichString-iOS
 //
 //  Created by Felipe Lefèvre Marino on 1/17/19.
@@ -8,31 +8,30 @@
 
 import UIKit
 
-/// DynamicTextSize encapsulate the attributes to setup the fonts to automatically scale to match the current Dynamic Type settings.
-public class DynamicTextSize {
+/// DynamicText encapsulate the attributes for fonts to automatically scale to match the current Dynamic Type settings. It uses UIFontMetrics.
+public class DynamicText {
     
     /// Set the dynamic size text style.
     /// You can pass any `UIFont.TextStyle` value, if nil UIFontMetrics.default will be used,
-    /// which uses the body text style
-    public var textStyle: UIFont.TextStyle?
+    /// which uses the body text style.
+    public var style: UIFont.TextStyle?
     
     #if os(OSX) || os(iOS) || os(tvOS)
-    /// Set the trait collection which the dynamic size is compatbile with
     /// The trait collection to use when determining compatibility. The returned
     /// font is appropriate for use in an interface that adopts the specified traits.
     public var traitCollection: UITraitCollection?
     #endif
     
-    /// Set the maximum font/text size
+    /// Set the maximum size
     /// allowed for the font/text. Use this value to constrain the font to
     /// the specified size when your interface cannot accommodate text that is any larger.
     public var maximumSize: CGFloat?
     
-    public typealias InitHandler = ((DynamicTextSize) -> (Void))
+    public typealias InitHandler = ((DynamicText) -> (Void))
     
     //MARK: - INIT
     
-    /// Initialize a new dynamic text size with optional configuration handler callback.
+    /// Initialize a new dynamic text with optional configuration handler callback.
     ///
     /// - Parameter handler: configuration handler callback.
     public init(_ handler: InitHandler? = nil) {

--- a/Sources/SwiftRichString/Attributes/DynamicTextSize.swift
+++ b/Sources/SwiftRichString/Attributes/DynamicTextSize.swift
@@ -1,0 +1,41 @@
+//
+//  DynamicTextSize.swift
+//  SwiftRichString-iOS
+//
+//  Created by Felipe Lefèvre Marino on 1/17/19.
+//  Copyright © 2019 SwiftRichString. All rights reserved.
+//
+
+import UIKit
+
+/// DynamicTextSize encapsulate the attributes to setup the fonts to automatically scale to match the current Dynamic Type settings.
+public class DynamicTextSize {
+    
+    /// Set the dynamic size text style.
+    /// You can pass any `UIFont.TextStyle` value, if nil UIFontMetrics.default will be used,
+    /// which uses the body text style
+    public var textStyle: UIFont.TextStyle?
+    
+    #if os(OSX) || os(iOS) || os(tvOS)
+    /// Set the trait collection which the dynamic size is compatbile with
+    /// The trait collection to use when determining compatibility. The returned
+    /// font is appropriate for use in an interface that adopts the specified traits.
+    public var traitCollection: UITraitCollection?
+    #endif
+    
+    /// Set the maximum font/text size
+    /// allowed for the font/text. Use this value to constrain the font to
+    /// the specified size when your interface cannot accommodate text that is any larger.
+    public var maximumSize: CGFloat?
+    
+    public typealias InitHandler = ((DynamicTextSize) -> (Void))
+    
+    //MARK: - INIT
+    
+    /// Initialize a new dynamic text size with optional configuration handler callback.
+    ///
+    /// - Parameter handler: configuration handler callback.
+    public init(_ handler: InitHandler? = nil) {
+        handler?(self)
+    }
+}

--- a/Sources/SwiftRichString/Attributes/FontData.swift
+++ b/Sources/SwiftRichString/Attributes/FontData.swift
@@ -30,6 +30,9 @@ public class FontData {
     
     /// Adjusts to dynamic font
     var adjustsToDynamicSize: Bool? { didSet { self.style?.invalidateCache() } }
+    
+    /// Text style
+    var textStyle: UIFont.TextStyle? { didSet { self.style?.invalidateCache() } }
 	
 	/// Size of the font
 	var size: CGFloat? { didSet { self.style?.invalidateCache() } }
@@ -187,11 +190,13 @@ public class FontData {
 		}
 		#endif
 		
+        // assign composed font - scaled when is set to adjust to dynamic size
         if #available(iOS 11.0, *), adjustsToDynamicSize == true {
-            finalAttributes[.font] = UIFontMetrics.default.scaledFont(for: finalFont)
+            finalAttributes[.font] = UIFontMetrics(forTextStyle: textStyle ?? .body).scaledFont(for: finalFont)
         } else {
-            finalAttributes[.font] = finalFont // assign composed font
+            finalAttributes[.font] = finalFont
         }
+        
 		return finalAttributes
 	}
 	

--- a/Sources/SwiftRichString/Attributes/FontData.swift
+++ b/Sources/SwiftRichString/Attributes/FontData.swift
@@ -29,10 +29,10 @@ public class FontData {
 	var font: FontConvertible? { didSet { self.style?.invalidateCache() } }
     
     // Dynamic text atributes
-    public var dynamicTextSize: DynamicTextSize? { didSet { self.style?.invalidateCache() } }
+    public var dynamicText: DynamicText? { didSet { self.style?.invalidateCache() } }
     
     /// Returns if font should adapt to dynamic type
-    private var adpatsToDynamicType: Bool? { return dynamicTextSize != nil }
+    private var adpatsToDynamicType: Bool? { return dynamicText != nil }
 	
 	/// Size of the font
 	var size: CGFloat? { didSet { self.style?.invalidateCache() } }
@@ -190,24 +190,6 @@ public class FontData {
 		}
 		#endif
         
-        /// Returns a custom scalable font based on the received font
-        ///
-        /// - Parameter font: font in which the custom font will be based
-        /// - Returns: dynamic scalable font
-        @available(iOS 11.0, tvOS 11.0, iOSApplicationExtension 11.0, watchOS 4, *)
-        func scalableFont(from font: Font) -> Font {
-            var fontMetrics: UIFontMetrics?
-            if let textStyle = dynamicTextSize?.textStyle {
-                fontMetrics = UIFontMetrics(forTextStyle: textStyle)
-            }
-            
-            #if os(OSX) || os(iOS) || os(tvOS)
-            return (fontMetrics ?? UIFontMetrics.default).scaledFont(for: font, maximumPointSize: dynamicTextSize?.maximumSize ?? 0.0, compatibleWith: dynamicTextSize?.traitCollection)
-            #else
-            return (fontMetrics ?? UIFontMetrics.default).scaledFont(for: font, maximumPointSize: dynamicTextSize?.maximumSize ?? 0.0)
-            #endif
-        }
-		
         // set scalable custom font if adapts to dynamic type
         if #available(iOS 11.0, *), adpatsToDynamicType == true {
             finalAttributes[.font] = scalableFont(from: finalFont)
@@ -217,4 +199,22 @@ public class FontData {
         
 		return finalAttributes
 	}
+    
+    /// Returns a custom scalable font based on the received font
+    ///
+    /// - Parameter font: font in which the custom font will be based
+    /// - Returns: dynamic scalable font
+    @available(iOS 11.0, tvOS 11.0, iOSApplicationExtension 11.0, watchOS 4, *)
+    private func scalableFont(from font: Font) -> Font {
+        var fontMetrics: UIFontMetrics?
+        if let textStyle = dynamicText?.style {
+            fontMetrics = UIFontMetrics(forTextStyle: textStyle)
+        }
+        
+        #if os(OSX) || os(iOS) || os(tvOS)
+        return (fontMetrics ?? UIFontMetrics.default).scaledFont(for: font, maximumPointSize: dynamicText?.maximumSize ?? 0.0, compatibleWith: dynamicText?.traitCollection)
+        #else
+        return (fontMetrics ?? UIFontMetrics.default).scaledFont(for: font, maximumPointSize: dynamicText?.maximumSize ?? 0.0)
+        #endif
+    }
 }

--- a/Sources/SwiftRichString/Attributes/FontData.swift
+++ b/Sources/SwiftRichString/Attributes/FontData.swift
@@ -27,6 +27,9 @@ public class FontData {
 	
 	/// Font object
 	var font: FontConvertible? { didSet { self.style?.invalidateCache() } }
+    
+    /// Adjusts to dynamic font
+    var adjustsToDynamicSize: Bool? { didSet { self.style?.invalidateCache() } }
 	
 	/// Size of the font
 	var size: CGFloat? { didSet { self.style?.invalidateCache() } }
@@ -184,7 +187,11 @@ public class FontData {
 		}
 		#endif
 		
-		finalAttributes[.font] = finalFont // assign composed font
+        if #available(iOS 11.0, *), adjustsToDynamicSize == true {
+            finalAttributes[.font] = UIFontMetrics.default.scaledFont(for: finalFont)
+        } else {
+            finalAttributes[.font] = finalFont // assign composed font
+        }
 		return finalAttributes
 	}
 	

--- a/Sources/SwiftRichString/Style/Style.swift
+++ b/Sources/SwiftRichString/Style/Style.swift
@@ -89,6 +89,7 @@ public class Style: StyleProtocol {
     
     /// Set the dynamic text attributes to adapt the font/text to the current Dynamic Type settings.
     /// **Note**: in order to be used you must also set the `.font`/`.size` attribute of the style.
+    @available(iOS 11.0, tvOS 11.0, iOSApplicationExtension 11.0, watchOS 4, *)
     public var dynamicText: DynamicText? {
         set { self.fontData?.dynamicText = newValue }
         get { return self.fontData?.dynamicText }

--- a/Sources/SwiftRichString/Style/Style.swift
+++ b/Sources/SwiftRichString/Style/Style.swift
@@ -86,6 +86,11 @@ public class Style: StyleProtocol {
 			return self.fontData?.font
 		}
 	}
+    
+    public var adjustsToDynamicSize: Bool? {
+        set { self.fontData?.adjustsToDynamicSize = newValue }
+        get { return self.fontData?.adjustsToDynamicSize }
+    }
 
 	/// Set the text color of the style.
 	/// You can pass any `ColorConvertible` conform object, it will be transformed to a valid `UIColor`/`NSColor`

--- a/Sources/SwiftRichString/Style/Style.swift
+++ b/Sources/SwiftRichString/Style/Style.swift
@@ -87,9 +87,16 @@ public class Style: StyleProtocol {
 		}
 	}
     
+    /// Define if the font adjusts to user dynamic size settings.
     public var adjustsToDynamicSize: Bool? {
         set { self.fontData?.adjustsToDynamicSize = newValue }
         get { return self.fontData?.adjustsToDynamicSize }
+    }
+    
+    /// Set the font preferred text style
+    public var textStyle: UIFont.TextStyle? {
+        set { self.fontData?.textStyle = newValue }
+        get { return self.fontData?.textStyle }
     }
 
 	/// Set the text color of the style.

--- a/Sources/SwiftRichString/Style/Style.swift
+++ b/Sources/SwiftRichString/Style/Style.swift
@@ -87,10 +87,11 @@ public class Style: StyleProtocol {
 		}
 	}
     
-    /// Set the dynamic text size attributes to adapt the font/text to the current Dynamic Type settings.
-    public var dynamicTextSize: DynamicTextSize? {
-        set { self.fontData?.dynamicTextSize = newValue }
-        get { return self.fontData?.dynamicTextSize }
+    /// Set the dynamic text attributes to adapt the font/text to the current Dynamic Type settings.
+    /// **Note**: in order to be used you must also set the `.font`/`.size` attribute of the style.
+    public var dynamicText: DynamicText? {
+        set { self.fontData?.dynamicText = newValue }
+        get { return self.fontData?.dynamicText }
     }
 
 	/// Set the text color of the style.

--- a/Sources/SwiftRichString/Style/Style.swift
+++ b/Sources/SwiftRichString/Style/Style.swift
@@ -87,16 +87,10 @@ public class Style: StyleProtocol {
 		}
 	}
     
-    /// Define if the font adjusts to user dynamic size settings.
-    public var adjustsToDynamicSize: Bool? {
-        set { self.fontData?.adjustsToDynamicSize = newValue }
-        get { return self.fontData?.adjustsToDynamicSize }
-    }
-    
-    /// Set the font preferred text style
-    public var textStyle: UIFont.TextStyle? {
-        set { self.fontData?.textStyle = newValue }
-        get { return self.fontData?.textStyle }
+    /// Set the dynamic text size attributes to adapt the font/text to the current Dynamic Type settings.
+    public var dynamicTextSize: DynamicTextSize? {
+        set { self.fontData?.dynamicTextSize = newValue }
+        get { return self.fontData?.dynamicTextSize }
     }
 
 	/// Set the text color of the style.

--- a/SwiftRichString.xcodeproj/project.pbxproj
+++ b/SwiftRichString.xcodeproj/project.pbxproj
@@ -185,14 +185,14 @@
 		8933C78E1EB5B82C000D00A4 /* SwiftRichStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7891EB5B82A000D00A4 /* SwiftRichStringTests.swift */; };
 		8933C78F1EB5B82C000D00A4 /* SwiftRichStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7891EB5B82A000D00A4 /* SwiftRichStringTests.swift */; };
 		8933C7901EB5B82D000D00A4 /* SwiftRichStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7891EB5B82A000D00A4 /* SwiftRichStringTests.swift */; };
-		D53F4E7B21F03E690085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
-		D53F4E7C21F03EEE0085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
-		D53F4E7D21F03EEF0085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
-		D53F4E7E21F03EEF0085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
-		D53F4E7F21F03F230085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
-		D53F4E8021F03F240085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
-		D53F4E8121F03F240085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
-		D53F4E8221F03F250085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
+		D53F4E7B21F03E690085D26F /* DynamicText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicText.swift */; };
+		D53F4E7C21F03EEE0085D26F /* DynamicText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicText.swift */; };
+		D53F4E7D21F03EEF0085D26F /* DynamicText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicText.swift */; };
+		D53F4E7E21F03EEF0085D26F /* DynamicText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicText.swift */; };
+		D53F4E7F21F03F230085D26F /* DynamicText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicText.swift */; };
+		D53F4E8021F03F240085D26F /* DynamicText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicText.swift */; };
+		D53F4E8121F03F240085D26F /* DynamicText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicText.swift */; };
+		D53F4E8221F03F250085D26F /* DynamicText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicText.swift */; };
 		DD7502881C68FEDE006590AF /* SwiftRichString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6DA0F1BF000BD002C0205 /* SwiftRichString.framework */; };
 		DD7502921C690C7A006590AF /* SwiftRichString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D9F01BEFFFBE002C0205 /* SwiftRichString.framework */; };
 /* End PBXBuildFile section */
@@ -320,7 +320,7 @@
 		8933C7891EB5B82A000D00A4 /* SwiftRichStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftRichStringTests.swift; sourceTree = "<group>"; };
 		AD2FAA261CD0B6D800659CF4 /* SwiftRichString.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SwiftRichString.plist; sourceTree = "<group>"; };
 		AD2FAA281CD0B6E100659CF4 /* SwiftRichStringTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SwiftRichStringTests.plist; sourceTree = "<group>"; };
-		D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTextSize.swift; sourceTree = "<group>"; };
+		D53F4E7A21F03E690085D26F /* DynamicText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicText.swift; sourceTree = "<group>"; };
 		DD75027A1C68FCFC006590AF /* SwiftRichString-macOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftRichString-macOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD75028D1C690C7A006590AF /* SwiftRichString-tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftRichString-tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -485,7 +485,7 @@
 				648932D3209DE44E000E691A /* FontConvertible.swift */,
 				64893308209DE7C5000E691A /* ColorConvertible.swift */,
 				6489332420A0CA76000E691A /* FontInfoAttribute.swift */,
-				D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */,
+				D53F4E7A21F03E690085D26F /* DynamicText.swift */,
 			);
 			path = Attributes;
 			sourceTree = "<group>";
@@ -1058,7 +1058,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D53F4E7B21F03E690085D26F /* DynamicTextSize.swift in Sources */,
+				D53F4E7B21F03E690085D26F /* DynamicText.swift in Sources */,
 				648932CA209DE194000E691A /* CommonsAttributes.swift in Sources */,
 				64507EBE20B18489009455BD /* Extensions.swift in Sources */,
 				64507E8D20AF3A9C009455BD /* StyleProtocol.swift in Sources */,
@@ -1093,7 +1093,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D53F4E7D21F03EEF0085D26F /* DynamicTextSize.swift in Sources */,
+				D53F4E7D21F03EEF0085D26F /* DynamicText.swift in Sources */,
 				648932CC209DE194000E691A /* CommonsAttributes.swift in Sources */,
 				64507EC020B18489009455BD /* Extensions.swift in Sources */,
 				64507E8F20AF3A9C009455BD /* StyleProtocol.swift in Sources */,
@@ -1120,7 +1120,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D53F4E7E21F03EEF0085D26F /* DynamicTextSize.swift in Sources */,
+				D53F4E7E21F03EEF0085D26F /* DynamicText.swift in Sources */,
 				648932CD209DE194000E691A /* CommonsAttributes.swift in Sources */,
 				64507EC120B18489009455BD /* Extensions.swift in Sources */,
 				64507E9020AF3A9C009455BD /* StyleProtocol.swift in Sources */,
@@ -1147,7 +1147,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D53F4E7C21F03EEE0085D26F /* DynamicTextSize.swift in Sources */,
+				D53F4E7C21F03EEE0085D26F /* DynamicText.swift in Sources */,
 				648932CB209DE194000E691A /* CommonsAttributes.swift in Sources */,
 				64507EBF20B18489009455BD /* Extensions.swift in Sources */,
 				64507E8E20AF3A9C009455BD /* StyleProtocol.swift in Sources */,
@@ -1178,7 +1178,7 @@
 				64507EEA20B18F20009455BD /* StyleProtocol.swift in Sources */,
 				64507EF120B18F20009455BD /* AttributedString+Ext.swift in Sources */,
 				64507EDE20B18F0F009455BD /* AppDelegate.swift in Sources */,
-				D53F4E8021F03F240085D26F /* DynamicTextSize.swift in Sources */,
+				D53F4E8021F03F240085D26F /* DynamicText.swift in Sources */,
 				64507EEC20B18F20009455BD /* StyleGroup.swift in Sources */,
 				64507EF920B18F20009455BD /* AssociatedValues.swift in Sources */,
 				64507EF320B18F20009455BD /* UIKit+Extras.swift in Sources */,
@@ -1206,7 +1206,7 @@
 				64507F2920B1912B009455BD /* String+Ext.swift in Sources */,
 				64507F1420B1911B009455BD /* NotificationController.swift in Sources */,
 				64507F3320B1912B009455BD /* AssociatedValues.swift in Sources */,
-				D53F4E7F21F03F230085D26F /* DynamicTextSize.swift in Sources */,
+				D53F4E7F21F03F230085D26F /* DynamicText.swift in Sources */,
 				64507F2420B1912B009455BD /* StyleProtocol.swift in Sources */,
 				64507F3220B1912B009455BD /* FontInfoAttribute.swift in Sources */,
 				64507F2D20B1912B009455BD /* UIKit+Extras.swift in Sources */,
@@ -1237,7 +1237,7 @@
 				648932EE209DE47C000E691A /* CommonsAttributes.swift in Sources */,
 				64507E9120AF3A9C009455BD /* StyleProtocol.swift in Sources */,
 				64893322209DED04000E691A /* StyleGroup.swift in Sources */,
-				D53F4E8221F03F250085D26F /* DynamicTextSize.swift in Sources */,
+				D53F4E8221F03F250085D26F /* DynamicText.swift in Sources */,
 				64507EBB20B1766D009455BD /* StyleRegEx.swift in Sources */,
 				64507E7C20AEF611009455BD /* OrderedDictionary.swift in Sources */,
 				64507E8A20AF3609009455BD /* String+Subscript.swift in Sources */,
@@ -1266,7 +1266,7 @@
 				64893323209DED04000E691A /* StyleGroup.swift in Sources */,
 				64507E7620AEF12C009455BD /* AssociatedValues.swift in Sources */,
 				648932FA209DE6C5000E691A /* ViewController.swift in Sources */,
-				D53F4E8121F03F240085D26F /* DynamicTextSize.swift in Sources */,
+				D53F4E8121F03F240085D26F /* DynamicText.swift in Sources */,
 				64507EBC20B1766D009455BD /* StyleRegEx.swift in Sources */,
 				64507EA020AF4681009455BD /* String+Ext.swift in Sources */,
 				64507E9220AF3A9C009455BD /* StyleProtocol.swift in Sources */,

--- a/SwiftRichString.xcodeproj/project.pbxproj
+++ b/SwiftRichString.xcodeproj/project.pbxproj
@@ -185,6 +185,14 @@
 		8933C78E1EB5B82C000D00A4 /* SwiftRichStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7891EB5B82A000D00A4 /* SwiftRichStringTests.swift */; };
 		8933C78F1EB5B82C000D00A4 /* SwiftRichStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7891EB5B82A000D00A4 /* SwiftRichStringTests.swift */; };
 		8933C7901EB5B82D000D00A4 /* SwiftRichStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8933C7891EB5B82A000D00A4 /* SwiftRichStringTests.swift */; };
+		D53F4E7B21F03E690085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
+		D53F4E7C21F03EEE0085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
+		D53F4E7D21F03EEF0085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
+		D53F4E7E21F03EEF0085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
+		D53F4E7F21F03F230085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
+		D53F4E8021F03F240085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
+		D53F4E8121F03F240085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
+		D53F4E8221F03F250085D26F /* DynamicTextSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */; };
 		DD7502881C68FEDE006590AF /* SwiftRichString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6DA0F1BF000BD002C0205 /* SwiftRichString.framework */; };
 		DD7502921C690C7A006590AF /* SwiftRichString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D9F01BEFFFBE002C0205 /* SwiftRichString.framework */; };
 /* End PBXBuildFile section */
@@ -312,6 +320,7 @@
 		8933C7891EB5B82A000D00A4 /* SwiftRichStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftRichStringTests.swift; sourceTree = "<group>"; };
 		AD2FAA261CD0B6D800659CF4 /* SwiftRichString.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SwiftRichString.plist; sourceTree = "<group>"; };
 		AD2FAA281CD0B6E100659CF4 /* SwiftRichStringTests.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = SwiftRichStringTests.plist; sourceTree = "<group>"; };
+		D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTextSize.swift; sourceTree = "<group>"; };
 		DD75027A1C68FCFC006590AF /* SwiftRichString-macOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftRichString-macOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD75028D1C690C7A006590AF /* SwiftRichString-tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftRichString-tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -476,6 +485,7 @@
 				648932D3209DE44E000E691A /* FontConvertible.swift */,
 				64893308209DE7C5000E691A /* ColorConvertible.swift */,
 				6489332420A0CA76000E691A /* FontInfoAttribute.swift */,
+				D53F4E7A21F03E690085D26F /* DynamicTextSize.swift */,
 			);
 			path = Attributes;
 			sourceTree = "<group>";
@@ -1048,6 +1058,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D53F4E7B21F03E690085D26F /* DynamicTextSize.swift in Sources */,
 				648932CA209DE194000E691A /* CommonsAttributes.swift in Sources */,
 				64507EBE20B18489009455BD /* Extensions.swift in Sources */,
 				64507E8D20AF3A9C009455BD /* StyleProtocol.swift in Sources */,
@@ -1082,6 +1093,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D53F4E7D21F03EEF0085D26F /* DynamicTextSize.swift in Sources */,
 				648932CC209DE194000E691A /* CommonsAttributes.swift in Sources */,
 				64507EC020B18489009455BD /* Extensions.swift in Sources */,
 				64507E8F20AF3A9C009455BD /* StyleProtocol.swift in Sources */,
@@ -1108,6 +1120,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D53F4E7E21F03EEF0085D26F /* DynamicTextSize.swift in Sources */,
 				648932CD209DE194000E691A /* CommonsAttributes.swift in Sources */,
 				64507EC120B18489009455BD /* Extensions.swift in Sources */,
 				64507E9020AF3A9C009455BD /* StyleProtocol.swift in Sources */,
@@ -1134,6 +1147,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D53F4E7C21F03EEE0085D26F /* DynamicTextSize.swift in Sources */,
 				648932CB209DE194000E691A /* CommonsAttributes.swift in Sources */,
 				64507EBF20B18489009455BD /* Extensions.swift in Sources */,
 				64507E8E20AF3A9C009455BD /* StyleProtocol.swift in Sources */,
@@ -1164,6 +1178,7 @@
 				64507EEA20B18F20009455BD /* StyleProtocol.swift in Sources */,
 				64507EF120B18F20009455BD /* AttributedString+Ext.swift in Sources */,
 				64507EDE20B18F0F009455BD /* AppDelegate.swift in Sources */,
+				D53F4E8021F03F240085D26F /* DynamicTextSize.swift in Sources */,
 				64507EEC20B18F20009455BD /* StyleGroup.swift in Sources */,
 				64507EF920B18F20009455BD /* AssociatedValues.swift in Sources */,
 				64507EF320B18F20009455BD /* UIKit+Extras.swift in Sources */,
@@ -1191,6 +1206,7 @@
 				64507F2920B1912B009455BD /* String+Ext.swift in Sources */,
 				64507F1420B1911B009455BD /* NotificationController.swift in Sources */,
 				64507F3320B1912B009455BD /* AssociatedValues.swift in Sources */,
+				D53F4E7F21F03F230085D26F /* DynamicTextSize.swift in Sources */,
 				64507F2420B1912B009455BD /* StyleProtocol.swift in Sources */,
 				64507F3220B1912B009455BD /* FontInfoAttribute.swift in Sources */,
 				64507F2D20B1912B009455BD /* UIKit+Extras.swift in Sources */,
@@ -1221,6 +1237,7 @@
 				648932EE209DE47C000E691A /* CommonsAttributes.swift in Sources */,
 				64507E9120AF3A9C009455BD /* StyleProtocol.swift in Sources */,
 				64893322209DED04000E691A /* StyleGroup.swift in Sources */,
+				D53F4E8221F03F250085D26F /* DynamicTextSize.swift in Sources */,
 				64507EBB20B1766D009455BD /* StyleRegEx.swift in Sources */,
 				64507E7C20AEF611009455BD /* OrderedDictionary.swift in Sources */,
 				64507E8A20AF3609009455BD /* String+Subscript.swift in Sources */,
@@ -1249,6 +1266,7 @@
 				64893323209DED04000E691A /* StyleGroup.swift in Sources */,
 				64507E7620AEF12C009455BD /* AssociatedValues.swift in Sources */,
 				648932FA209DE6C5000E691A /* ViewController.swift in Sources */,
+				D53F4E8121F03F240085D26F /* DynamicTextSize.swift in Sources */,
 				64507EBC20B1766D009455BD /* StyleRegEx.swift in Sources */,
 				64507EA020AF4681009455BD /* String+Ext.swift in Sources */,
 				64507E9220AF3A9C009455BD /* StyleProtocol.swift in Sources */,


### PR DESCRIPTION
### Why
To support dynamic text size.

### Changes
- Add  DynamicText class to allow supporting Dynamic Type texts.
- Add `dynamicText` property to style.
- Update iOS Example with a style supporting dynamic type.
- Update readme.

I hope to be contributing 😄.
It's related to #32 