### PR TITLE
Fixes for regular expression to parse generic tags

### DIFF
--- a/Sources/SwiftRichString/Style/StyleGroup.swift
+++ b/Sources/SwiftRichString/Style/StyleGroup.swift
@@ -86,7 +86,7 @@ public class StyleGroup: StyleProtocol {
 		private func extractParametersFromTags(_ string: String) -> [String: String]? {
 			guard let _ = string.firstIndex(of: " ") else { return nil } // no tags
 
-			let pattern = "\\w*\\s*=\\s*\"?\\s*([\\w\\s%#\\/\\.;:_-]*)\\s*\"?.*?" // maybe shorter?
+			let pattern = "\\w*\\s*=\\s*\"?\\s*([^\"]*)\\s*\"?.*?" // maybe shorter?
 			guard let regex = try? NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators) else {
 				return nil
 			}

--- a/Sources/SwiftRichString/Style/StyleGroup.swift
+++ b/Sources/SwiftRichString/Style/StyleGroup.swift
@@ -86,7 +86,7 @@ public class StyleGroup: StyleProtocol {
 		private func extractParametersFromTags(_ string: String) -> [String: String]? {
 			guard let _ = string.firstIndex(of: " ") else { return nil } // no tags
 
-			let pattern = "\\w*\\s*=\\s*\"?\\s*([^\"]*)\\s*\"?.*?" // maybe shorter?
+			let pattern = "\\w*\\s*=\\s*\"?\\s*([^\"][^\"]*)\\s*\"?.*?" // maybe shorter?
 			guard let regex = try? NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators) else {
 				return nil
 			}


### PR DESCRIPTION
In **href** Current REGEX not working for **tel://** and **custom routes** which we created for our project. Here My solution is just matching with all texts whatever inside the href double quotes.