### PR TITLE
Allow dashes in tag attribute names

### DIFF
--- a/Sources/SwiftRichString/Style/StyleGroup.swift
+++ b/Sources/SwiftRichString/Style/StyleGroup.swift
@@ -86,7 +86,7 @@ public class StyleGroup: StyleProtocol {
 		private func extractParametersFromTags(_ string: String) -> [String: String]? {
 			guard let _ = string.firstIndex(of: " ") else { return nil } // no tags
 
-			let pattern = "\\w*\\s*=\\s*\"?\\s*([^\"][^\"]*)\\s*\"?.*?" // maybe shorter?
+			let pattern = "[\\w-]*\\s*=\\s*\"?\\s*([^\"][^\"]*)\\s*\"?.*?" // maybe shorter?
 			guard let regex = try? NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators) else {
 				return nil
 			}


### PR DESCRIPTION
Example:

`<a href="https://www.google.com" my-custom-data="someinterestinginformation">`

The current regex pattern would parse the name of the second attribute as "data". The new regex also allows for dashes in the name and would extract the full attribute name "my-custom-data".