### PR TITLE
Use fontDescriptor for instantiating a UIFont from an existing UIFont

### DIFF
--- a/Sources/SwiftRichString/Attributes/FontConvertible.swift
+++ b/Sources/SwiftRichString/Attributes/FontConvertible.swift
@@ -62,7 +62,7 @@ extension Font: FontConvertible {
 		#elseif os(watchOS)
 		return Font(name: self.fontName, size: (size ?? WATCHOS_SYSTEMFONT_SIZE))!
 		#else
-		return Font(name: self.fontName, size: (size ?? Font.systemFontSize))!
+		return Font(descriptor: self.fontDescriptor, size: (size ?? Font.systemFontSize))
 		#endif
 	}
 	


### PR DESCRIPTION
Workaround for issue https://openradar.appspot.com/6153065 related to iOS 13 SDK. When instantiating a system font via its fontName, the created font is always Times New Roman.