### PR TITLE
Fix iOS 13 font regression (Times New Roman)

### DIFF
--- a/ExampleiOS/Base.lproj/Main.storyboard
+++ b/ExampleiOS/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.13.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.9"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,8 +21,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="M2v-v6-dEE">
-                                <rect key="frame" x="10" y="30" width="355" height="627"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <rect key="frame" x="10" y="10" width="355" height="647"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>

--- a/Sources/SwiftRichString/Attributes/FontConvertible.swift
+++ b/Sources/SwiftRichString/Attributes/FontConvertible.swift
@@ -51,7 +51,7 @@ public protocol FontConvertible {
 
 // MARK: - FontConvertible for UIFont/NSFont
 extension Font: FontConvertible {
-	
+
 	/// Return the same instance of the font with specified size.
 	///
 	/// - Parameter size: size of the font in points. If size is `nil`, `Font.systemFontSize` is used.
@@ -59,20 +59,20 @@ extension Font: FontConvertible {
 	public func font(size: CGFloat?) -> Font {
 		#if os(tvOS)
 		return Font(name: self.fontName, size: (size ?? TVOS_SYSTEMFONT_SIZE))!
-        #elseif os(iOS)
-        return Font(name: self.fontName, size: (size ?? Font.systemFontSize))!
 		#elseif os(watchOS)
 		return Font(name: self.fontName, size: (size ?? WATCHOS_SYSTEMFONT_SIZE))!
 		#elseif os(macOS)
-        return Font(descriptor: self.fontDescriptor, size: (size ?? Font.systemFontSize))!
+    return Font(descriptor: self.fontDescriptor, size: (size ?? Font.systemFontSize))!
+    #else
+    return Font(descriptor: self.fontDescriptor, size: (size ?? Font.systemFontSize))
 		#endif
 	}
-	
+
 }
 
 // MARK: - FontConvertible for String
 extension String: FontConvertible {
-	
+
 	/// Transform a string to a valid `UIFont`/`NSFont` instance.
 	/// String must contain a valid Postscript font's name.
 	///
@@ -87,5 +87,5 @@ extension String: FontConvertible {
 		return Font(name: self, size: (size ?? Font.systemFontSize))!
 		#endif
 	}
-	
+
 }

--- a/Sources/SwiftRichString/Attributes/FontConvertible.swift
+++ b/Sources/SwiftRichString/Attributes/FontConvertible.swift
@@ -62,9 +62,9 @@ extension Font: FontConvertible {
 		#elseif os(watchOS)
 		return Font(name: self.fontName, size: (size ?? WATCHOS_SYSTEMFONT_SIZE))!
 		#elseif os(macOS)
-    return Font(descriptor: self.fontDescriptor, size: (size ?? Font.systemFontSize))!
-    #else
-    return Font(descriptor: self.fontDescriptor, size: (size ?? Font.systemFontSize))
+		return Font(descriptor: self.fontDescriptor, size: (size ?? Font.systemFontSize))!
+		#else
+		return Font(descriptor: self.fontDescriptor, size: (size ?? Font.systemFontSize))
 		#endif
 	}
 


### PR DESCRIPTION
For #84.

(the storyboard change is to make the background adaptive. otherwise it's showing up as black for me in iOS 13)